### PR TITLE
Always enable runtime in statistics

### DIFF
--- a/src/html/settings.html
+++ b/src/html/settings.html
@@ -29,17 +29,16 @@
     <label for="windowsToTabs">Tabs instead of windows</label>
 
     <hr>
+
     <h4>Advanced (beginners, go away!)</h4>
     <label>Logic tick (ms)
       <input type="number" id="timerTick" min="50" max="20000" value="300">
     </label>
     <br>
+    
     <hr>
-    <h4>Statistic window</h4>
-    <input type="checkbox" id="showRuntime" />
-    <label for="showRuntime">Show runtime</label>
-    <br>
 
+    <h4>Statistic window</h4>
     <h5>Speed format</h5>
     <input type="radio" id="speedFormat_min" name="speedFormat" value="min">
     <label for="speedFormat_min">uri/min.</label>

--- a/src/html/settings.js
+++ b/src/html/settings.js
@@ -10,7 +10,6 @@ function saveOptions(e) {
     windowColor: $("#windowColor").val(),
     windowOpacity: $("#windowOpacity").val(),
     timerTick: $("#timerTick").val(),
-    showRuntime: $("#showRuntime").prop('checked'),
     speedFormat: $('input[name="speedFormat"]:checked').val(),
     windowsToTabs: $("#windowsToTabs").prop('checked'),
   };
@@ -19,7 +18,7 @@ function saveOptions(e) {
 }
 
 function restore() {
-  var items = ["headerColor", "headerOpacity", "windowColor", "windowOpacity", "timerTick", "showRuntime", "speedFormat", "windowsToTabs"];
+  var items = ["headerColor", "headerOpacity", "windowColor", "windowOpacity", "timerTick", "speedFormat", "windowsToTabs"];
 
   var onGet = items => {
 

--- a/src/js/preferences/GlobalSettings.js
+++ b/src/js/preferences/GlobalSettings.js
@@ -7,7 +7,6 @@ class GlobalSettings {
       windowColor: "#191919",
       windowOpacity: "0.8",
       timerTick: 300,
-      showRuntime: false,
       speedFormat: 'hour',
       windowsToTabs: false,
     }, items => {
@@ -37,10 +36,6 @@ class GlobalSettings {
 
   get speedFormat() {
     return this._settings.speedFormat;
-  }
-
-  get showRuntime() {
-    return this._settings.showRuntime;
   }
 
   get windowsToTabs() {

--- a/src/js/windows/StatisticWindow.js
+++ b/src/js/windows/StatisticWindow.js
@@ -81,15 +81,14 @@ class StatisticWindow {
         labelText: 'Speed: ',
         spanText: '0.00 uri/min.',
         appendTo: this.botStatisticWindow
+      },
+      {
+        name: 'runtime',
+        labelText: 'Runtime: ',
+        spanText: '00:00:00',
+        appendTo: this.botStatisticWindow
       }
     ];
-
-    options.push({
-      name: 'runtime',
-      labelText: 'Runtime: ',
-      spanText: '00:00:00',
-      appendTo: this.botStatisticWindow
-    });
 
     options.forEach((option) => {
       this[option.name] = ControlFactory.info(option);

--- a/src/js/windows/StatisticWindow.js
+++ b/src/js/windows/StatisticWindow.js
@@ -84,14 +84,12 @@ class StatisticWindow {
       }
     ];
 
-    if (window.globalSettings.showRuntime) {
-      options.push({
-        name: 'runtime',
-        labelText: 'Runtime: ',
-        spanText: '00:00:00',
-        appendTo: this.botStatisticWindow
-      });
-    }
+    options.push({
+      name: 'runtime',
+      labelText: 'Runtime: ',
+      spanText: '00:00:00',
+      appendTo: this.botStatisticWindow
+    });
 
     options.forEach((option) => {
       this[option.name] = ControlFactory.info(option);
@@ -170,11 +168,7 @@ class StatisticWindow {
 
     $(window).on('logicEnd', () => {
       if (this.connected) {
-
-        if (window.globalSettings.showRuntime) {
-          $('span:last-child', this.runtime).text(TimeHelper.diff(this.stats.startTime));
-        }
-
+        $('span:last-child', this.runtime).text(TimeHelper.diff(this.stats.startTime));
         $('span:last-child', this.speed).text(this.speedFormat(this.stats.uridium, this.stats.startTime));
       }
     });


### PR DESCRIPTION
Why was there a switch in the first place? It makes more sense to just have it enabled